### PR TITLE
doc: Add notice about feature availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ In OpenTofu 1.7.0-beta1 and upwards you can configure the provider and pass it a
 
 This feature is an experimental preview and is subject to change before the OpenTofu 1.7.0 release.
 
+> :warning: When writing Go, the features available depend on the version of
+> Go used to build the relevant OpenTofu release you're using.  For example,
+> OpenTofu 1.7.0 was built with Go 1.21, so features only available in 1.22+
+> will not work and may result in obscure error messages.
+
 ## Example
 
 ```hcl


### PR DESCRIPTION
While experimenting with this provider, I regularly encountered issues that were very obscure in nature.  For example, the following Go code, which is valid in 1.22+, was causing my func to fail:

```go
package lib
import "fmt"
func Example() string {
        for _ := range 5 {
                fmt.Println("Hello")
        }
        return "hi"
}
```

The error was:

```
│ Error: Plugin did not respond
│
│ The plugin encountered an error, and failed to respond to the plugin6.(*GRPCProvider).ConfigureProvider call. The plugin logs may contain more details.
╵

Stack trace from the terraform-provider-go_v0.0.3 plugin:

panic: nil type

goroutine 57 [running]:
log.Panic({0xc000722c60?, 0xc000722c70?, 0xb75435?})
	log/log.go:432 +0x5a
github.com/traefik/yaegi/interp.(*scope).add(0xc0001dd170, 0x0)
	github.com/traefik/yaegi@v0.16.1/interp/scope.go:207 +0x54
github.com/traefik/yaegi/interp.(*Interpreter).cfg.func1(0xc0001e23c0)
	github.com/traefik/yaegi@v0.16.1/interp/cfg.go:202 +0x474b
github.com/traefik/yaegi/interp.(*node).Walk(0xc0001e23c0, 0xc000723330, 0xc0007232d8)
	github.com/traefik/yaegi@v0.16.1/interp/interp.go:282 +0x2e
github.com/traefik/yaegi/interp.(*node).Walk(0xc0003f9e00, 0xc000723330, 0xc0007232d8)
	github.com/traefik/yaegi@v0.16.1/interp/interp.go:286 +0x6b
github.com/traefik/yaegi/interp.(*node).Walk(0xc0003f9cc0, 0xc000723330, 0xc0007232d8)
	github.com/traefik/yaegi@v0.16.1/interp/interp.go:286 +0x6b
github.com/traefik/yaegi/interp.(*node).Walk(0xc0003f92c0, 0xc000723330, 0xc0007232d8)
	github.com/traefik/yaegi@v0.16.1/interp/interp.go:286 +0x6b
github.com/traefik/yaegi/interp.(*node).Walk(0xc0003f8000, 0xc000723330, 0xc0007232d8)
	github.com/traefik/yaegi@v0.16.1/interp/interp.go:286 +0x6b
github.com/traefik/yaegi/interp.(*node).Walk(0xc0003f5e00, 0xc000723330, 0xc0007232d8)
	github.com/traefik/yaegi@v0.16.1/interp/interp.go:286 +0x6b
github.com/traefik/yaegi/interp.(*Interpreter).cfg(0xc000196248, 0xc0003f5e00, 0xc0001dd170, {0xc0006a1950, 0x3}, {0xc0006a1950, 0x3})
	github.com/traefik/yaegi@v0.16.1/interp/cfg.go:69 +0x29a
github.com/traefik/yaegi/interp.(*Interpreter).CompileAST(0xc000196248, {0x13174d8?, 0xc0000c4140?})
	github.com/traefik/yaegi@v0.16.1/interp/program.go:97 +0x14d
github.com/traefik/yaegi/interp.(*Interpreter).compileSrc(0xc000196248, {0xc000460200?, 0xffffffffffffffff?}, {0x0?, 0xc0007233b0?}, 0xb0?)
	github.com/traefik/yaegi@v0.16.1/interp/program.go:64 +0xaa
github.com/traefik/yaegi/interp.(*Interpreter).eval(0xc000196248, {0xc000460200?, 0x0?}, {0x0?, 0x0?}, 0x0?)
	github.com/traefik/yaegi@v0.16.1/interp/interp.go:554 +0x25
github.com/traefik/yaegi/interp.(*Interpreter).Eval(...)
	github.com/traefik/yaegi@v0.16.1/interp/interp.go:496
main.main.func1.1(0xc000490b10)
	github.com/opentofu/terraform-provider-go/main.go:177 +0x588
main.(*FunctionProvider).ConfigureProvider(0xc00017fb40, {0xc0004ae1e0?, 0xfce5c0?}, 0xc000490b10?)
	github.com/opentofu/terraform-provider-go/main.go:58 +0x27
github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server.(*server).ConfigureProvider(0xc00024aa00, {0x131c4c0?, 0xc000490300?}, 0xc0004921c0)
	github.com/hashicorp/terraform-plugin-go@v0.22.1/tfprotov6/tf6server/server.go:558 +0x2ca
github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/tfplugin6._Provider_ConfigureProvider_Handler({0x10d7920, 0xc00024aa00}, {0x131c4c0, 0xc000490300}, 0xc000496080, 0x0)
	github.com/hashicorp/terraform-plugin-go@v0.22.1/tfprotov6/internal/tfplugin6/tfplugin6_grpc.pb.go:464 +0x1a6
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0001b9200, {0x131c4c0, 0xc000490270}, {0x1322b20, 0xc00047c000}, 0xc0004d0000, 0xc00039af30, 0x1a1d890, 0x0)
	google.golang.org/grpc@v1.62.1/server.go:1386 +0xdf8
google.golang.org/grpc.(*Server).handleStream(0xc0001b9200, {0x1322b20, 0xc00047c000}, 0xc0004d0000)
	google.golang.org/grpc@v1.62.1/server.go:1797 +0xe87
google.golang.org/grpc.(*Server).serveStreams.func2.1()
	google.golang.org/grpc@v1.62.1/server.go:1027 +0x8b
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 36
	google.golang.org/grpc@v1.62.1/server.go:1038 +0x125

Error: The terraform-provider-go_v0.0.3 plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.
```

This error message was very opaque to me.  After a bit of version checking, I discovered that this plugin is built with 1.22, both OpenTofu 1.7.0 is built with 1.21.  I'm not sure where the issue is, if it's something that can even be fixed/changed, but at least in the mean time figured a warning in the README here might be helpful.