### PR TITLE
Fix copy/paste error in conversion to Go float64

### DIFF
--- a/main.go
+++ b/main.go
@@ -429,7 +429,7 @@ func TfToGoValue(goType reflect.Type, tfValue tftypes.Value) (any, error) {
 			return nil, err
 		}
 
-		f, _ := bigFloat.Int64()
+		f, _ := bigFloat.Float64()
 		return f, nil
 	case reflect.Ptr:
 		if tfValue.IsNull() {


### PR DESCRIPTION
Fixes copy/paste error in conversion of a Terraform proto number to Go float64.